### PR TITLE
Add babel preset-env for gulp build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gulp-sourcemaps": "^1.3.0",
     "gulp-stylus": "^2.0.0",
     "run-sequence": "^1.0.2",
-    "stylus": "*"
+    "stylus": "*",
+    "@babel/preset-env": "^7.24.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `@babel/preset-env` to devDependencies

## Testing
- `grep -n preset-env -n gulpfile.js`
