### PR TITLE
Update vendor library versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,9 +13,9 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "~2.1.3",
-    "requirejs": "~2.1.15",
-    "q": "1.0.1",
-    "sprintf": "~1.0.2"
+    "jquery": "~3.7.1",
+    "requirejs": "~2.3.6",
+    "q": "~1.5.1",
+    "sprintf": "~1.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- upgrade jquery to ~3.7.1
- upgrade requirejs to ~2.3.6
- upgrade q to ~1.5.1
- upgrade sprintf to ~1.1.2

## Testing
- `npm test` *(fails: Missing script)*