### PR TITLE
Update build system to gulp 4 and modern babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,15 +8,14 @@
   "dependencies": {
   },
   "devDependencies": {
-    "babel-core": "^5.8.22",
-    "del": "^1.1.1",
-    "gulp": "^3.8.10",
-    "gulp-6to5": "^3.0.0",
+    "@babel/core": "^7.24.0",
+    "del": "^7.0.0",
+    "gulp": "^4.0.2",
+    "gulp-babel": "^8.0.0",
     "gulp-connect": "^2.2.0",
     "gulp-rename": "^1.2.0",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-stylus": "^2.0.0",
-    "run-sequence": "^1.0.2",
     "stylus": "*"
   }
 }


### PR DESCRIPTION
## Summary
- replace `gulp-6to5` with `gulp-babel`
- migrate `gulpfile.js` to Gulp 4 syntax
- bump `@babel/core` and `gulp` versions
- drop obsolete `run-sequence`

## Testing
- `gulp` *(fails: command not found)*
- `npx gulp` *(hangs – dependencies not installed)*
